### PR TITLE
Detect empty string for InputEvent.inputType

### DIFF
--- a/examples/input-events.html
+++ b/examples/input-events.html
@@ -113,7 +113,7 @@
     }
 
     function inputTypeToStringForEvent(event) {
-        if (!event.inputType)
+        if (event.inputType == null)
             return "(null)";
 
         return `"${event.inputType}"`;


### PR DESCRIPTION
Currently Safari gives `inputType: ""` for events after `document.execCommand()`, which is being represented as `(null)` in the example. (Bug: https://bugs.webkit.org/show_bug.cgi?id=201128)

This patch makes the example to correctly show empty strings as `""`.