### PR TITLE
Change font-family from `-apple-system` to `system-ui`

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -5,10 +5,11 @@
 <link rel="canonical" href="https://whsieh.github.io/examples" />
 <style>
 body {
-    font-family: -apple-system;
+    font-family: system-ui;
     font-size: 1em;
     margin: 1em;
 }
+
 .container {
     margin-top: 1em;
 }


### PR DESCRIPTION
Change the font-family of the examples index from `-apple-system` to `system-ui`, for compatibility with other platforms.